### PR TITLE
Fix undefined inputValue error

### DIFF
--- a/index.js
+++ b/index.js
@@ -430,10 +430,11 @@ var SpreadsheetWorksheet = function( spreadsheet, data ){
     spreadsheet.makeFeedRequest(self['_links']['bulkcells'], 'POST', data_xml, function(err, data) {
       if (err) return cb(err);
 
-      // update all the cells
+      // update all the cells with a title
       var cells_by_batch_id = _.indexBy(cells, 'batchId');
       if (data.entry && data.entry.length) data.entry.forEach(function(cell_data) {
-        cells_by_batch_id[cell_data['batch:id']].updateValuesFromResponseData(cell_data);
+        if (cell_data.title != "Error")
+          {cells_by_batch_id[cell_data['batch:id']].updateValuesFromResponseData(cell_data)};
       });
       cb();
     });
@@ -537,8 +538,6 @@ var SpreadsheetCell = function( spreadsheet, worksheet_id, data ){
   self.updateValuesFromResponseData = function(_data) {
     // formula value
     var input_val = _data['gs:cell']['$']['inputValue'];
-    // inputValue can be undefined so substr throws an error
-    // still unsure how this situation happens
     if (input_val && input_val.substr(0,1) === '='){
       self._formula = input_val;
     } else {


### PR DESCRIPTION
An undefined inputValue will be generated if there is a "makeFeedRequest" for cell data on a deleted sheet (I assume this is possible because async schedules both the cell update and sheet deletion, but the cell update is scheduled after the deletion).
To solve for this, you can check if a cell "Title" returns an "Error" and then exclude that cell from the "updateValuesFromResponseData" update.